### PR TITLE
Fixed bug

### DIFF
--- a/public/javascripts/game_client.js
+++ b/public/javascripts/game_client.js
@@ -33,7 +33,7 @@ socket.on("end match", function(winner, reason) {
 
 socket.on("no rematch", function() {
 	labels["rematch"].disabled = true;
-	labels["rematch"].visible = true;
+	labels["rematch"].visible = false;
 	labels["waiting"].visible = false;
 });
 


### PR DESCRIPTION
Hvis der vælges ikke at lave et rematch, forsvinder teksten "No rematch" ikke, og bliver bare stående i menuen helt forkert. Tror det her burde rette det
